### PR TITLE
Birden fazla timer oluşma sorunu çözüldü

### DIFF
--- a/src/Utilities/Timer.js
+++ b/src/Utilities/Timer.js
@@ -6,6 +6,10 @@ import RoomService from "../Services/Room";
 
   static startTimer = async (id) =>  {
     let room = await RoomService.findRedisRoom(id);
+    if(this.timers[room.id]){
+      return;
+    }
+    
     this.timers[room.id] = setInterval ( async () => {
       let duration = await RoomService.getVideoDuration(id);
       room.video.duration = duration + 1;
@@ -14,6 +18,10 @@ import RoomService from "../Services/Room";
   }
 
   static stopTimer(id) {
+    if(!this.timers[id]){
+      return;
+    }
+
     clearInterval(this.timers[id]);
     delete this.timers[id];
   }


### PR DESCRIPTION
Bir odada bir kişi video durdurma tuşuna bastığında o odadaki kişi sayısı kadar olay sunucuda tetikleniyor, aynı işleyiş başlatma tuşu için de geçerli.

Başlatma tuşuna basıldığında timer oluşturuyor ve id'sini bir obje içinde oda id'si ile bağlıyoruz fakat şu anda olduğu gibi yanlışlıkla aynı oda için birden fazla timer oluşturulursa sadece son istekteki id oda'idsi ile birleştiriliyor ve geri kalanlar çalışmaya devam ediyor. Aşağıdaki ekran resiminde kod video durdurulduğunda `t:{}` yazacak şekilde yeniden kurgulanmıştır ve 2 kişilik bir odada sadece bir kişi videoyu durdurduğunda konsola iki kere yazım yapmıştır.
![image](https://user-images.githubusercontent.com/56413673/197364906-72acf327-7b93-46e4-bada-a042f86dd2fb.png)
