### PR TITLE
dockerfile and docker-compose-yaml added

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.env
+node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:18-alpine3.15
+
+ARG NODE_ENV=production
+ARG PORT=3000
+ARG YOUTUBE_API_KEY=
+ARG MONGO_CONNECTION_STRING=
+ARG REDIS_CONNECTION_STRING=
+
+# environment variables
+ENV NODE_ENV=$NODE_ENV
+ENV PORT=$PORT
+ENV YOUTUBE_API_KEY=$YOUTUBE_API_KEY
+ENV MONGO_CONNECTION_STRING=$MONGO_CONNECTION_STRING
+ENV REDIS_CONNECTION_STRING=$REDIS_CONNECTION_STRING
+
+# create project directory
+WORKDIR /usr/src/pingu-api
+
+# bundle app source
+COPY . .
+
+# install dependencies
+# enviroment is development because we use babel
+RUN NODE_ENV=development npm install
+RUN npm run build
+
+EXPOSE $app_port
+CMD ["npm", "run", "start"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: "3.9"
+services:
+  backend:
+    build: .
+    depends_on:
+      - "redis-server"
+      - "mongo-server"
+    ports:
+      - "3001:3000"
+    volumes:
+      - .:/code
+    environment:
+      - MONGO_CONNECTION_STRING=mongodb://root:123456@mongo-server:27017
+      - REDIS_CONNECTION_STRING=redis://redis-server:6379
+      - APP_PORT=3000
+  redis-server:
+    image: "redis:alpine"
+  mongo-server:
+    image: mongo
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: 123456

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The best way to watch YouTube by video chatting with friends.",
   "main": "src/server.js",
   "scripts": {
-    "start": "npm run build && node dist/server.js",
+    "start": "node dist/server.js",
     "start:dev": "nodemon start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/sample.env
+++ b/sample.env
@@ -2,3 +2,4 @@ NODE_ENV=development
 PORT=3000
 YOUTUBE_API_KEY=your_youtube_api_key
 MONGO_CONNECTION_STRING=mongodb://username:password@localhost:port/database
+REDIS_CONNECTION_STRING=redis://redis-server:6379

--- a/src/Services/Room/index.js
+++ b/src/Services/Room/index.js
@@ -15,7 +15,12 @@ const schema = {
   messages: [],
 };
 
-const redisRoomModel = new Model(schema, 'rooms', { keyUnique: 'id' });
+const redisRoomModel = new Model(schema, 'rooms', {
+  keyUnique: 'id',
+  redisClientOptions: {
+    url: process.env.REDIS_CONNECTION_STRING,
+  },
+});
 
 const createRoom = async ({
   id, username, roomName, videoUrl,


### PR DESCRIPTION
Docker ile projeyi yayınlama kolaylığına erişebiliriz. `docker-compose.yaml` dosyasına yaptığımız konfigrasyonlar sayesinde docker compose bize birden fazla container'ı organize edebilme yeteneğini sağlıyor. Dosyanın içinde `redis-server`, `mongo-server` ve `backend` adıyla üç adet, aynı networkte olan servis oluşturuyoruz. Her biri kendi ismiyle domain'e sahip olan ayrı bir container bundan dolayı herhangi bir bağlantı kurarken `localhost` gibi host ismi yerine servisin ismi yazılmalıdır.

`docker compose up` veya `docker-compose up` komutu compose dosyasını okuyarak projeyi tek komutta ayağa kaldıracaktır.

Bağlantı url'leri gibi ortam değişkenlerinin bazıları doğrudan compose dosyası içinde tanımlanmışken youtube key'i gibi gizli bilgileri `.env` dosyasında tutarsanız `docker compose up` komutu çalıştığında varsayılan olarak oradaki bilgileri de ortam değişkenleri içine ekleyecektir.