### PR TITLE
development container added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.15
+FROM node:18-alpine3.15 AS backend
 
 ARG NODE_ENV=production
 ARG PORT=3000
@@ -26,3 +26,30 @@ RUN npm run build
 
 EXPOSE $app_port
 CMD ["npm", "run", "start"]
+
+
+FROM node:18-alpine3.15 AS development
+ARG NODE_ENV=development
+ARG PORT=3000
+ARG YOUTUBE_API_KEY=
+ARG MONGO_CONNECTION_STRING=
+ARG REDIS_CONNECTION_STRING=
+
+# environment variables
+ENV NODE_ENV=$NODE_ENV
+ENV PORT=$PORT
+ENV YOUTUBE_API_KEY=$YOUTUBE_API_KEY
+ENV MONGO_CONNECTION_STRING=$MONGO_CONNECTION_STRING
+ENV REDIS_CONNECTION_STRING=$REDIS_CONNECTION_STRING
+
+# create project directory
+WORKDIR /usr/src/pingu-api
+
+# bundle app source
+COPY . .
+
+# install dependencies
+RUN npm install
+
+EXPOSE $app_port
+CMD ["npm", "run", "start:dev"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,18 +1,33 @@
 version: "3.9"
 services:
   backend:
-    build: .
+    build:
+      context: .
+      target: backend
     depends_on:
       - "redis-server"
       - "mongo-server"
     ports:
-      - "3001:3000"
-    volumes:
-      - .:/code
+      - "3000:3000"
     environment:
       - MONGO_CONNECTION_STRING=mongodb://root:123456@mongo-server:27017
       - REDIS_CONNECTION_STRING=redis://redis-server:6379
-      - APP_PORT=3000
+      - PORT=3000
+  backend-dev:
+    build:
+      context: .
+      target: development
+    depends_on:
+      - "redis-server"
+      - "mongo-server"
+    ports:
+      - "3001:3001"
+    volumes:
+      - .:/usr/src/pingu-api
+    environment:
+      - MONGO_CONNECTION_STRING=mongodb://root:123456@mongo-server:27017
+      - REDIS_CONNECTION_STRING=redis://redis-server:6379
+      - PORT=3001
   redis-server:
     image: "redis:alpine"
   mongo-server:


### PR DESCRIPTION
+ `backend` servisi `3000`'e portlandı.
+ geliştirme ortamında kolaylık sağlaması için kodu takip edecek, `3001`'e portlanmış `backend-dev` adında yeni bir docker servisi eklendi. `docker compose up` ile container'ları ayağa kaldırdıktan sonra geliştirme yapmaya başlayabiliriz.

+ `docker-compose.yaml` dosyasındaki hatalı olan `APP_PORT` değişkeni düzeltildi.
